### PR TITLE
monitoring: Adding condition to NOT install monitoring if not defined

### DIFF
--- a/roles/common/tasks/post/main.yml
+++ b/roles/common/tasks/post/main.yml
@@ -10,3 +10,4 @@
   tags: ntp
 - include: sensu.yml
   tags: sensu-client
+  when: "'monitoring' in group_names"

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
 - include: checks.yml
+  when: "'monitoring' in group_names"

--- a/roles/masters/tasks/main.yml
+++ b/roles/masters/tasks/main.yml
@@ -4,6 +4,8 @@
 - include: crontab.yml
   tags: crontab
 - include: service_accounts.yml
+  when: "'monitoring' in group_names"
 - include: sensu.yml
+  when: "'monitoring' in group_names"
 - include: bashrc.yml
   tags: bashrc

--- a/roles/masters/tasks/service_accounts.yml
+++ b/roles/masters/tasks/service_accounts.yml
@@ -20,6 +20,7 @@
   command: /tmp/metrics_sa.sh
   register: command_result
   changed_when: "command_result.stdout.find('CHANGED') != -1"
+  when: "'monitoring' in group_names"
 
 - name: create service account monitoring
   command: /tmp/monitoring_sa.sh

--- a/roles/nodes/tasks/main.yml
+++ b/roles/nodes/tasks/main.yml
@@ -9,4 +9,6 @@
 - include: collectd.yml
   tags:
     - collectd
+  when: "'monitoring' in group_names"
 - include: logstash.yml
+  when: "'monitoring' in group_names"


### PR DESCRIPTION
It might happen that for certain project/POC/customer, we might not want
to install the monitoring/metrics/logging part. This adds a first
'general' case where you don't have any of those things. So the
condition has been added everywhere some monitoring elements were
failing.

@TODO: Adding extra condition IN tasks to filter by: metric / logs /
monitoring

Edit: Added https://github.com/redhat-cip/rcip-openshift-ansible/issues/8 for the reference
