### PR TITLE
update rgexp hostname for collectd

### DIFF
--- a/roles/common/tasks/post/collectd_config.yml
+++ b/roles/common/tasks/post/collectd_config.yml
@@ -16,7 +16,7 @@
       - restart collectd
   with_items:
     - { regexp: '^FQDNLookup', line: 'FQDNLookup false' }
-    - { regexp: '^Hostname .*$', line: "Hostname {{ inventory_hostname }}" }
+    - { regexp: '^Hostname .*$', line: "Hostname \"{{ inventory_hostname }}\"" }
     - { regexp: '^Include "/etc/collectd.d"$', line: 'Include "/etc/collectd.d"' }
   when: dockerbuild is undefined
 


### PR DESCRIPTION
Since collectd is now collectd-5.5.2-1.el7.x86_64 on RHEL 7, we noticed that hostname was not well retieved
